### PR TITLE
Bug fixes and improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,26 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-toolchains-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>toolchain</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <toolchains>
+            <jdk>
+              <version>[1.7,1.8)</version>
+            </jdk>
+          </toolchains>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <artifactId>maven-plugin-plugin</artifactId>
         <configuration>
           <!-- see http://jira.codehaus.org/browse/MNG-5346 -->
@@ -177,6 +197,11 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-toolchains-plugin</artifactId>
+          <version>1.0</version>
+        </plugin>
+        <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.1</version>
         </plugin>
@@ -204,7 +229,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.4.1</version>
+          <version>2.5</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -262,7 +287,7 @@
     <project.reporting.outputEncoding>utf-8</project.reporting.outputEncoding>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <mavenVersion>3.0.5</mavenVersion>
-    <maven.plugin.version>3.2</maven.plugin.version>
+    <maven.plugin.version>3.3</maven.plugin.version>
   </properties>
   
 </project>


### PR DESCRIPTION
Fixed command line options (no duplicates, correct escaping and using single-dash instead of double-dash as the latest jdeps requires)
Fixed java toolchain support
Bound to verify phase by default for bound executions
Fixed logging
Bound mojo parameters to system properties that can be specified on command line
